### PR TITLE
Update OAuth.js

### DIFF
--- a/src/OAuth.js
+++ b/src/OAuth.js
@@ -107,7 +107,13 @@ OAuth.getBaseUriString = function getBaseUriString(uri) {
 	const pathname = uriAsUrl.pathname;
 
 	// Remove query and fragment
-	return `${protocol}//${hostname}${pathname}`;
+	var baseUri=`${protocol}//${hostname}`;
+	if(uriAsUrl.port !== undefined && uriAsUrl.port !== null && uriAsUrl.port!==443 && uriAsUrl!==80) {
+		baseUri += ':' + uriAsUrl.port;
+	}
+	baseUri += `${pathname}`;
+
+	return baseUri;
 };
 
 /**

--- a/src/OAuth.js
+++ b/src/OAuth.js
@@ -108,7 +108,7 @@ OAuth.getBaseUriString = function getBaseUriString(uri) {
 
 	// Remove query and fragment
 	var baseUri=`${protocol}//${hostname}`;
-	if(uriAsUrl.port !== undefined && uriAsUrl.port !== null && uriAsUrl.port!==443 && uriAsUrl!==80) {
+	if(uriAsUrl.port !== undefined && uriAsUrl.port !== null && uriAsUrl.port!==443 && uriAsUrl.port!==80) {
 		baseUri += ':' + uriAsUrl.port;
 	}
 	baseUri += `${pathname}`;

--- a/src/OAuth.js
+++ b/src/OAuth.js
@@ -107,11 +107,17 @@ OAuth.getBaseUriString = function getBaseUriString(uri) {
 	const pathname = uriAsUrl.pathname;
 
 	// Remove query and fragment
-	var baseUri=`${protocol}//${hostname}`;
-	if(uriAsUrl.port !== undefined && uriAsUrl.port !== null && uriAsUrl.port!==443 && uriAsUrl.port!==80) {
-		baseUri += ':' + uriAsUrl.port;
+	let baseUri=`${protocol}//${hostname}`;
+	const hasNonStandardPort = (
+		uriAsUrl.port !== undefined &&
+		uriAsUrl.port !== null &&
+		uriAsUrl.port!==443 &&
+		uriAsUrl.port!==80
+	);
+	if(hasNonStandardPort) {
+		baseUri = `${baseUri}:${uriAsUrl.port}`
 	}
-	baseUri += `${pathname}`;
+	baseUri = `${baseUri}${pathname}`;
 
 	return baseUri;
 };


### PR DESCRIPTION
RFC 5849 section 3.4.1.2 (https://tools.ietf.org/html/rfc5849#section-3.4.1.2) states that:
       The port MUST be included if it is not the default port for the
       scheme, and MUST be excluded if it is the default.  Specifically,
       the port MUST be excluded when making an HTTP request [RFC2616]
       to port 80 or when making an HTTPS request [RFC2818] to port 443.
       All other non-default port numbers MUST be included.

This change should bring the implementation closer to specification and enable correct behavior during local testing on non-standard ports.