### PR TITLE
Closes #7 Take hash over empty string, if payload is empty.

### DIFF
--- a/src/OAuth.js
+++ b/src/OAuth.js
@@ -161,7 +161,7 @@ OAuth.getNonce = function getNonce() {
  */
 OAuth.getOAuthParams = function getOAuthParams(consumerKey, payload) {
 	const oauthParams = new Map();
-	if (!payload) payload = "";
+	if (!payload) payload = EMPTY_STRING;
 	oauthParams.set("oauth_body_hash", OAuth.getBodyHash(payload));
 	oauthParams.set("oauth_consumer_key", consumerKey);
 	oauthParams.set("oauth_nonce", OAuth.getNonce());

--- a/src/OAuth.js
+++ b/src/OAuth.js
@@ -161,7 +161,8 @@ OAuth.getNonce = function getNonce() {
  */
 OAuth.getOAuthParams = function getOAuthParams(consumerKey, payload) {
 	const oauthParams = new Map();
-	if (payload) oauthParams.set("oauth_body_hash", OAuth.getBodyHash(payload));
+	if (!payload) payload = "";
+	oauthParams.set("oauth_body_hash", OAuth.getBodyHash(payload));
 	oauthParams.set("oauth_consumer_key", consumerKey);
 	oauthParams.set("oauth_nonce", OAuth.getNonce());
 	oauthParams.set("oauth_signature_method", `RSA-SHA${SHA_BITS}`);

--- a/test/OAuth-getAuthorizationString.test.js
+++ b/test/OAuth-getAuthorizationString.test.js
@@ -12,7 +12,7 @@ const authorizationString = getAuthorizationString(oauthParams);
 describe("OAuth Signer", function() {
 	describe("#getAuthorizationString()", function() {
 		it("Creates a correctly formatted header", function() {
-			assert.equal(authorizationString, `OAuth oauth_consumer_key="aaa!aaa",oauth_nonce="uTeLPs6K",oauth_signature_method="RSA-SHA256",oauth_timestamp="1524771555",oauth_version="1.0"`);
+			assert.equal(authorizationString, `OAuth oauth_body_hash="47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=",oauth_consumer_key="aaa!aaa",oauth_nonce="uTeLPs6K",oauth_signature_method="RSA-SHA256",oauth_timestamp="1524771555",oauth_version="1.0"`);
 		});
 	});
 });

--- a/test/OAuth-getOAuthParams.test.js
+++ b/test/OAuth-getOAuthParams.test.js
@@ -4,7 +4,7 @@ const getOAuthParams = require("../src/OAuth").getOAuthParams;
 
 describe("OAuth Signer", function() {
 	describe("#getOAuthParams()", function() {
-		
+
 		const consumerKey = "aaa!aaa";
 		const myPayload = `{ my: "payload" }`;
 
@@ -12,6 +12,7 @@ describe("OAuth Signer", function() {
 			const oauthParams = getOAuthParams(consumerKey);
 			const mapKeysArray = Array.from(oauthParams.keys());
 			const paramsArr = [
+				"oauth_body_hash",
 				"oauth_consumer_key",
 				"oauth_nonce",
 				"oauth_signature_method",

--- a/test/OAuth.test.js
+++ b/test/OAuth.test.js
@@ -14,7 +14,7 @@ describe("OAuth Signer", function() {
 
 		it("Creates a valid OAuth1.0a signature with a body hash when payload is present", function() {
 			const header = OAuth.getAuthorizationHeader(uri, method, null, consumerKey, signingKey);
-			assert.equal(header, `OAuth oauth_consumer_key="aaa!aaa",oauth_nonce="uTeLPs6K",oauth_signature_method="RSA-SHA256",oauth_timestamp="1524771555",oauth_version="1.0",oauth_signature="XXX"`);
+			assert.equal(header, `OAuth oauth_body_hash="47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=",oauth_consumer_key="aaa!aaa",oauth_nonce="uTeLPs6K",oauth_signature_method="RSA-SHA256",oauth_timestamp="1524771555",oauth_version="1.0",oauth_signature="XXX"`);
 		});
 	});
 });


### PR DESCRIPTION
Add ouath_body_hash over empty string to OAuth signature, if payload is
empty or missing. Add oauth_body_hash in related tests.